### PR TITLE
Minor attribution in the getsize method

### DIFF
--- a/videos/080_python_slots/slots.py
+++ b/videos/080_python_slots/slots.py
@@ -70,7 +70,11 @@ def slots_class_example():
 
 
 def getsize(obj_0):
-    """Recursively iterate to sum size of object & members."""
+    """Recursively iterate to sum size of object & members.
+    
+    Note::
+        Adopted from https://github.com/bosswissam/pysize
+    """
     ZERO_DEPTH_BASES = (str, bytes, Number, range, bytearray)
     _seen_ids = set()
 


### PR DESCRIPTION
Giving some love to developers with minor visibility :)

The getsize method is adopted from [Wissam Jarjoui](https://github.com/bosswissam/pysize) (also [here](https://goshippo.com/blog/measure-real-size-any-python-object/)). This is just a minor attribution change to show some love to the community.

Note to the project owner: if the code similarities are purely accidental, my apologies -- feel free to discard.

Tests: Not required unless documentation is compiled from docstrings.