### PR TITLE
Follow HTTP 301 redirects

### DIFF
--- a/videos/063_find_why_your_python_code_is_slow_using_this_essential_tool_dot___feat_dot__async_await_/needs_profiling.py
+++ b/videos/063_find_why_your_python_code_is_slow_using_this_essential_tool_dot___feat_dot__async_await_/needs_profiling.py
@@ -32,7 +32,7 @@ async def better_count_https_in_web_pages():
         urls = [line.strip() for line in f.readlines()]
 
     async with httpx.AsyncClient() as client:
-        tasks = (client.get(url) for url in urls)
+        tasks = (client.get(url, follow_redirects=True) for url in urls)
         reqs = await asyncio.gather(*tasks)
 
     htmls = [req.text for req in reqs]


### PR DESCRIPTION
Hi James,

First of all I really enjoy your channel and explanations - thanks for sharing!

I was playing around with the async example, and didn't get the expected results - some troubleshooting showed that in my case, httpx was receiving mostly HTTP 301 redirects - leading to empty pages being parsed and links being incorrectly counted.

Turns out that's easily fixed by adding a statement in the line of code in this pull request.
 
FYI, I also pointed this out on your Youtube channel (I'm CritiKaster):
 
https://www.youtube.com/watch?v=m_a0fN48Alw


Kind regards,

Raoul